### PR TITLE
Fixes issue that prevents JSON from being parsed for custom APIs

### DIFF
--- a/Contents/Sketch/script.cocoascript
+++ b/Contents/Sketch/script.cocoascript
@@ -32,7 +32,7 @@ var onRun = function(context) {
         }
       }
     } else {
-      applyTypography(request(queryURL).result, doc.documentData().layerTextStyles());
+      applyTypography(JSON.parse(request(queryURL)).result, doc.documentData().layerTextStyles());
     }
   }
 


### PR DESCRIPTION
`request(queryURL)` returns a (presumably) JSON string that needs to be parsed as a dictionary if the data is expected in this format.

In `loadFromURL(queryURL)`, the section to grab data from a custom API does not parse the JSON string before attempting to use it as a dictionary, which prevents the plugin from working. This is fixed by parsing the JSON string in the same way that the script does for Google Sheets data.
